### PR TITLE
获取项目下 mock 列表最大数为1000

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -4,6 +4,8 @@ const _ = require('lodash')
 const chalk = require('chalk')
 const inquirer = require('inquirer')
 
+const MOCK_PAGE_SIZE = 1000
+
 function Migrate (onlineRequest, localRequest, localDomain) {
   this.onlineGroup = ''
   this.localGroup = ''
@@ -117,7 +119,7 @@ Migrate.prototype.migrate = function migrate (onlineProjects) {
   }
 
   Promise
-    .all(onlineProjects.map(id => this.onlineRequest.get('/mock', { params: { project_id: id } })))
+    .all(onlineProjects.map(id => this.onlineRequest.get('/mock', { params: { project_id: id, page_size: MOCK_PAGE_SIZE } })))
     .then(projects => projects.map(res => res.data.data))
     .then(projects => {
       projects.forEach(item => {


### PR DESCRIPTION
如果不设置 page_size ，默认是 30 条。在 mock 较多的情况下，不能够获取全部 mock。